### PR TITLE
fix: Update CHANGELOG.md for v0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,41 +5,41 @@
 ## Release notes:
 ### Bug Fixes
 
-* fix(security): fixed CVE-2023-45857 by backporting `withXSRFToken` option to v0.x (#6091)
+* fix(security): fixed CVE-2023-45857 by backporting `withXSRFToken` option to v0.x ([#6091](https://github.com/axios/axios/pull/6091))
 
 ### Backports from v1.x:
 
-* Allow null indexes on formSerializer and paramsSerializer v0.x (#4961)
-* Fixing content-type header repeated #4745
-* Fixed timeout error message for HTTP 4738
-* Added `axios.formToJSON` method (#4735)
-* URL params serializer (#4734)
-* Fixed toFormData Blob issue on node>v17 #4728
-* Adding types for progress event callbacks #4675
-* Fixed max body length defaults #4731
-* Added data URL support for node.js (#4725)
-* Added isCancel type assert (#4293)
-* Added the ability for the `url-encoded-form` serializer to respect the `formSerializer` config (#4721)
-* Add `string[]` to `AxiosRequestHeaders` type (#4322)
-* Allow type definition for axios instance methods (#4224)
-* Fixed `AxiosError` stack capturing; (#4718)
-* Fixed `AxiosError` status code type; (#4717)
-* Adding Canceler parameters config and request (#4711)
-* fix(types): allow to specify partial default headers for instance creation (#4185)
-* Added `blob` to the list of protocols supported by the browser (#4678)
-* Fixing Z_BUF_ERROR when no content (#4701)
-* Fixed race condition on immediate requests cancellation (#4261)
-* Added a clear() function to the request and response interceptors object so a user can ensure that all interceptors have been removed from an Axios instance https://github.com/axios/axios/pull/4248
-* Added generic AxiosAbortSignal TS interface to avoid importing AbortController polyfill (#4229)
-* Fix TS definition for AxiosRequestTransformer (#4201)
-* Use type alias instead of interface for AxiosPromise (#4505)
-* Include request and config when creating a CanceledError instance (#4659)
-* Added generic TS types for the exposed toFormData helper (#4668)
-* Optimized the code that checks cancellation (#4587)
-* Replaced webpack with rollup (#4596)
-* Added stack trace to AxiosError (#4624)
-* Updated AxiosError.config to be optional in the type definition (#4665)
-* Removed incorrect argument for NetworkError constructor (#4656)
+* Allow null indexes on formSerializer and paramsSerializer v0.x ([#4961](https://github.com/axios/axios/pull/4961))
+* Fixing content-type header repeated ([#4745](https://github.com/axios/axios/pull/4745))
+* Fixed timeout error message for HTTP ([#4738](https://github.com/axios/axios/pull/4738))
+* Added `axios.formToJSON` method ([#4735](https://github.com/axios/axios/pull/4735))
+* URL params serializer ([#4734](https://github.com/axios/axios/pull/4734))
+* Fixed toFormData Blob issue on node>v17 ([#4728](https://github.com/axios/axios/pull/4728))
+* Adding types for progress event callbacks ([#4675](https://github.com/axios/axios/pull/4675))
+* Fixed max body length defaults ([#4731](https://github.com/axios/axios/pull/4731))
+* Added data URL support for node.js ([#4725](https://github.com/axios/axios/pull/4725))
+* Added isCancel type assert ([#4293](https://github.com/axios/axios/pull/4293))
+* Added the ability for the `url-encoded-form` serializer to respect the `formSerializer` config ([#4721](https://github.com/axios/axios/pull/4721))
+* Add `string[]` to `AxiosRequestHeaders` type ([#4322](https://github.com/axios/axios/pull/4224))
+* Allow type definition for axios instance methods ([#4224](https://github.com/axios/axios/pull/4224))
+* Fixed `AxiosError` stack capturing; ([#4718](https://github.com/axios/axios/pull/4718))
+* Fixed `AxiosError` status code type; ([#4717](https://github.com/axios/axios/pull/4717))
+* Adding Canceler parameters config and request ([#4711](https://github.com/axios/axios/pull/4711))
+* fix(types): allow to specify partial default headers for instance creation ([#4185](https://github.com/axios/axios/pull/4185))
+* Added `blob` to the list of protocols supported by the browser ([#4678](https://github.com/axios/axios/pull/4678))
+* Fixing Z_BUF_ERROR when no content ([#4701](https://github.com/axios/axios/pull/4701))
+* Fixed race condition on immediate requests cancellation ([#4261](https://github.com/axios/axios/pull/4261))
+* Added a clear() function to the request and response interceptors object so a user can ensure that all interceptors have been removed from an Axios instance ([#4248](https://github.com/axios/axios/pull/4248))
+* Added generic AxiosAbortSignal TS interface to avoid importing AbortController polyfill ([#4229](https://github.com/axios/axios/pull/4229))
+* Fix TS definition for AxiosRequestTransformer ([#4201](https://github.com/axios/axios/pull/4201))
+* Use type alias instead of interface for AxiosPromise ([#4505](https://github.com/axios/axios/pull/4505))
+* Include request and config when creating a CanceledError instance ([#4659](https://github.com/axios/axios/pull/4659))
+* Added generic TS types for the exposed toFormData helper ([#4668](https://github.com/axios/axios/pull/4668))
+* Optimized the code that checks cancellation ([#4587](https://github.com/axios/axios/pull/4587))
+* Replaced webpack with rollup ([#4596](https://github.com/axios/axios/pull/4596))
+* Added stack trace to AxiosError ([#4624](https://github.com/axios/axios/pull/4624))
+* Updated AxiosError.config to be optional in the type definition ([#4665](https://github.com/axios/axios/pull/4665))
+* Removed incorrect argument for NetworkError constructor ([#4656](https://github.com/axios/axios/pull/4656))
 
 ## 0.27.2 (April 27, 2022)
 


### PR DESCRIPTION
I've noticed that links to PRs were broken while browsing docs. Here's a fix